### PR TITLE
Display svg in gridly layout

### DIFF
--- a/src/pages/Personal.js
+++ b/src/pages/Personal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { renderToString } from 'react-dom/server';
 import Navigation from '../components/Navigation';
 import useLocalStorage from '../scripts/localStorageData';
 
@@ -32,39 +33,43 @@ function Personal() {
 
     const svgImagePersonal = (
         <svg width="495" height={imgHeight} viewBox={`0 0 495 ${imgHeight}`} fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="0.5" y="0.5" width="99%" height="99%" rx="4.5" fill="#FFFEFE" stroke="#E4E2E2"/>
+            <rect x="0.5" y="0.5" width="99%" height="99%" rx="4.5" fill="#FFFEFE" stroke="#E4E2E2" />
             {personalFullnameText}
             {personalLanguagesText}
             {personalHobbiesText}
         </svg>
     );
 
+    const svgImagePersonalString = renderToString(svgImagePersonal);
+    localStorage.setItem('svgImagePersonalStored', svgImagePersonalString);
+
+
     return (
         <>
-            <Navigation/>
+            <Navigation />
             <div id="section-wrapper">
                 <div>
                     <section id="section">
                         <div id="form-wrapper">
                             <form>
                                 <div>
-                                    <label htmlFor="fullnameValue">My full name</label><br/>
-                                    <input onChange={valueChangePersonalFullname} value={valuePersonalFullname} type="text" id="fullnameValue" name="fullnameValue" minLength="0" maxLength="40"/>
+                                    <label htmlFor="fullnameValue">My full name</label><br />
+                                    <input onChange={valueChangePersonalFullname} value={valuePersonalFullname} type="text" id="fullnameValue" name="fullnameValue" minLength="0" maxLength="40" />
                                 </div>
                                 <div>
-                                    <label htmlFor="languagesValue">Languages I speak <span>(comma separated)</span></label><br/>
-                                    <input onChange={valueChangePersonalLanguages} value={valuePersonalLanguages} type="text" id="languagesValue" name="languagesValue" minLength="0" maxLength="40"/>
+                                    <label htmlFor="languagesValue">Languages I speak <span>(comma separated)</span></label><br />
+                                    <input onChange={valueChangePersonalLanguages} value={valuePersonalLanguages} type="text" id="languagesValue" name="languagesValue" minLength="0" maxLength="40" />
                                 </div>
                                 <div>
-                                    <label htmlFor="hobbiesValue">My hobbies <span>(comma separated)</span></label><br/>
-                                    <input onChange={valueChangePersonalHobbies} value={valuePersonalHobbies} type="text" id="hobbiesValue" name="hobbiesValue" minLength="0" maxLength="40"/>
+                                    <label htmlFor="hobbiesValue">My hobbies <span>(comma separated)</span></label><br />
+                                    <input onChange={valueChangePersonalHobbies} value={valuePersonalHobbies} type="text" id="hobbiesValue" name="hobbiesValue" minLength="0" maxLength="40" />
                                 </div>
                             </form>
                         </div>
                     </section>
                     <aside id="section-aside">
                         <h1>Notes:</h1>
-                        <p><span>*</span> all inputs are optional.<br/><span>*</span> comma separated example: English, French, ...<br/><span>*</span> for information about data, see <Link to="/privacy-policy">Privacy Policy</Link>.</p>
+                        <p><span>*</span> all inputs are optional.<br /><span>*</span> comma separated example: English, French, ...<br /><span>*</span> for information about data, see <Link to="/privacy-policy">Privacy Policy</Link>.</p>
                     </aside>
                 </div>
                 <div id="svg-wrapper">

--- a/src/pages/Programming.js
+++ b/src/pages/Programming.js
@@ -15,33 +15,33 @@ function Programming() {
     const imgHeight = (valueProgramming === '') ? 26 : 82;
 
     const svgImageProgramming = (
-        <g>
-            <rect x="0.5" y="0.5" width="494" height={imgHeight - 1} rx="4.5" fill="#FFFEFE" stroke="#E4E2E2"/>
+        <svg width="495" height={imgHeight} viewBox={`0 0 495 ${imgHeight}`} fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="0.5" y="0.5" width="494" height={imgHeight - 1} rx="4.5" fill="#FFFEFE" stroke="#E4E2E2" />
             {programmingText}
-        </g>
+        </svg>
     );
 
     const svgImageProgrammingString = renderToString(svgImageProgramming)
     localStorage.setItem('svgImageProgrammingStored', svgImageProgrammingString)
-    
+
     return (
         <>
-            <Navigation/>
+            <Navigation />
             <div id="section-wrapper">
                 <div>
                     <section id="section">
                         <div id="form-wrapper">
                             <form>
                                 <div>
-                                    <label htmlFor="programming">Programming languages I code in <span>(comma separated)</span></label><br/>
-                                    <input onChange={valueChangeProgramming} value={valueProgramming} type="text" id="programming" name="programming" minLength="0" maxLength="50"/>
+                                    <label htmlFor="programming">Programming languages I code in <span>(comma separated)</span></label><br />
+                                    <input onChange={valueChangeProgramming} value={valueProgramming} type="text" id="programming" name="programming" minLength="0" maxLength="50" />
                                 </div>
                             </form>
                         </div>
                     </section>
                     <aside id="section-aside">
                         <h1>Notes:</h1>
-                        <p><span>*</span> all inputs are optional.<br/><span>*</span> comma separated example: JavaScript, Ruby, ...<br/><span>*</span> non-programming languages are also included (eg. HTML).<br/><span>*</span> for information about data, see <Link to="/privacy-policy">Privacy Policy</Link>.</p>
+                        <p><span>*</span> all inputs are optional.<br /><span>*</span> comma separated example: JavaScript, Ruby, ...<br /><span>*</span> non-programming languages are also included (eg. HTML).<br /><span>*</span> for information about data, see <Link to="/privacy-policy">Privacy Policy</Link>.</p>
                     </aside>
                 </div>
                 <div>

--- a/src/pages/Result.js
+++ b/src/pages/Result.js
@@ -4,14 +4,37 @@ import parse from 'html-react-parser';
 import DOMPurify from 'dompurify';
 
 function Result() {
-    const width = 900;
-    const height = 192;
+    let svgImages = [];
+    let svgCards = [];
+    const width = 1000;
+    const height = 390;
 
     const svgImageProgrammingPassed = localStorage.getItem('svgImageProgrammingStored')
     const svgImageTechnologiesPassed = localStorage.getItem('svgImageTechnologiesStored')
+    const svgImagePersonalPassed = localStorage.getItem('svgImagePersonalStored')
 
     const svgImageProgrammingPassedClean = DOMPurify.sanitize(svgImageProgrammingPassed);
     const svgImageTechnologiesPassedClean = DOMPurify.sanitize(svgImageTechnologiesPassed);
+    const svgImagePersonalPassedClean = DOMPurify.sanitize(svgImagePersonalPassed);
+
+    svgImages.push(parse(svgImageProgrammingPassedClean));
+    svgImages.push(parse(svgImageTechnologiesPassedClean));
+    svgImages.push(parse(svgImagePersonalPassedClean));
+    console.log(svgImages);
+
+    let curHeight = 0;
+
+    for (let i = 0; i < svgImages.length; i++) {
+        let x = 0;
+        if (i % 2 !== 0) {
+            x = 500;
+        }
+        svgCards.push(<SvgCard svgImage={svgImages[i]} x={x} y={curHeight} key={i} />);
+
+        if (i % 2 !== 0) {
+            curHeight += Math.max(parseInt(svgImages[i].props.height), parseInt(svgImages[i - 1].props.height));
+        }
+    }
 
     const svgToPngUrl = (svgBlob) => new Promise((resolve) => {
         const image = new Image();
@@ -31,7 +54,7 @@ function Result() {
         const a = document.createElement('a');
         document.body.appendChild(a);
         const svgDoc = document.getElementById('result-svg');
-        const blob = new Blob([svgDoc.outerHTML], {type:'image/svg+xml;charset=utf-8'});
+        const blob = new Blob([svgDoc.outerHTML], { type: 'image/svg+xml;charset=utf-8' });
         let url = '';
         if (type === 'png') {
             url = await svgToPngUrl(blob);
@@ -45,13 +68,14 @@ function Result() {
         a.remove();
     }
 
+    let personalImg = <SvgCard svgImage={parse(svgImagePersonalPassedClean)} x="500" />;
+
     return (
         <>
-            <Navigation/>
+            <Navigation />
             <div id="result">
                 <svg id="result-svg" width={width} height={height} viewBox={`0 0 ${width} ${height}`} fill="none" xmlns="http://www.w3.org/2000/svg">
-                {parse(svgImageProgrammingPassedClean)}
-                {parse(svgImageTechnologiesPassedClean)}
+                    {svgCards}
                 </svg>
                 <button id="download-button" data-type="svg" onClick={download}>Download SVG</button>
                 <button id="download-button" data-type="png" onClick={download}>Download PNG</button>
@@ -59,5 +83,12 @@ function Result() {
         </>
     );
 }
+
+function SvgCard(props) {
+    return (
+        <svg {...props.svgImage.props} x={props.x} y={props.y}></svg>
+    );
+}
+
 
 export default Result;

--- a/src/pages/Technologies.js
+++ b/src/pages/Technologies.js
@@ -17,38 +17,39 @@ function Technologies() {
     const technologiesPositionByLocation = (currentPath == '/s/technologies') ? "0.5" : "50";*/
 
     const svgImageTechnologies = (
-        <g>
-            <rect x="0.5" y="0.5" width="494" height={imgHeight - 1} rx="4.5" fill="#FFFEFE" stroke="#E4E2E2"/>
+        <svg width="495" height={imgHeight} viewBox={`0 0 495 ${imgHeight}`} fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="0.5" y="0.5" width="494" height={imgHeight - 1} rx="4.5" fill="#FFFEFE" stroke="#E4E2E2" />
             {valueTechnologies !== '' && (
                 <text x="25" y="36">
                     <tspan x="25" y="36" fill="#2F80ED" fontFamily="Segoe UI" fontWeight="600" fontSize="18px">Technologies I use</tspan>
                     <tspan x="25" y="60" fill="#333" fontFamily="Segoe UI" fontWeight="400" fontSize="14px">{valueTechnologies}</tspan>
                 </text>
             )}
-        </g>
+        </svg>
     );
 
     const svgImageTechnologiesString = renderToString(svgImageTechnologies)
     localStorage.setItem('svgImageTechnologiesStored', svgImageTechnologiesString)
 
+
     return (
         <>
-            <Navigation/>
+            <Navigation />
             <div id="section-wrapper">
                 <div>
                     <section id="section">
                         <div id="form-wrapper">
                             <form>
                                 <div>
-                                    <label htmlFor="technologies">Technologies I use <span>(comma separated)</span></label><br/>
-                                    <input onChange={valueChangeTechnologies} value={valueTechnologies} type="text" id="technologies" name="technologies" minLength="0" maxLength="50"/>
+                                    <label htmlFor="technologies">Technologies I use <span>(comma separated)</span></label><br />
+                                    <input onChange={valueChangeTechnologies} value={valueTechnologies} type="text" id="technologies" name="technologies" minLength="0" maxLength="50" />
                                 </div>
                             </form>
                         </div>
                     </section>
                     <aside id="section-aside">
                         <h1>Notes:</h1>
-                        <p><span>*</span> all inputs are optional.<br/><span>*</span> comma separated example: Visual Studio Code, React, ...<br/><span>*</span> for information about data, see <Link to="/privacy-policy">Privacy Policy</Link>.</p>
+                        <p><span>*</span> all inputs are optional.<br /><span>*</span> comma separated example: Visual Studio Code, React, ...<br /><span>*</span> for information about data, see <Link to="/privacy-policy">Privacy Policy</Link>.</p>
                     </aside>
                 </div>
                 <div>


### PR DESCRIPTION
Hi @JoseDeFreitas ,
Here is a solution for displaying the images in table of n rows and 2 columns.

The result.js will fetch each svg from the other pages. Whilst parsing them into React components, also modifying their x  & y props, which is the position being displayed. This is made easy using a wrapping component (SvgCard).

Note that I changed from using <g> (grouping tag) to <svg> (for programming and technology), since <svg> can easily move its children along with it when the (x,y) changes.

To add more images, you just need to repeat the importing code. I've wrote the logic for assigning (x,y).

Any comments, please let me know.

Cheers,
Alex.

Example result:
![image](https://user-images.githubusercontent.com/31884589/95437307-8ffbe700-09a0-11eb-89e8-329e87aff205.png)

